### PR TITLE
Fix validation rule and add tests

### DIFF
--- a/app/Http/Controllers/API/WordController.php
+++ b/app/Http/Controllers/API/WordController.php
@@ -58,7 +58,9 @@ class WordController extends Controller
         // Validate the request data
         $validator = Validator::make($request->all(), [
             'english_word' => 'required|string|max:255',
-            'part_of_speech_id' => 'required|integer|exists:Pos,id',
+            // Use the correct table name for the exists rule
+            // The table storing parts of speech is named "pos"
+            'part_of_speech_id' => 'required|integer|exists:pos,id',
             'translation' => 'required|string|max:255',
         ]);
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/WordUpdateTest.php
+++ b/tests/Feature/WordUpdateTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Word;
+use App\Models\Pos;
+use App\Models\Translation;
+
+class WordUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_update_word_with_valid_part_of_speech(): void
+    {
+        $pos = Pos::create(['part_of_speech' => 'noun']);
+        $word = Word::create(['english_word' => 'apple']);
+        $translation = Translation::create([
+            'word_id' => $word->id,
+            'part_of_speech_id' => $pos->id,
+            'translation' => 'old',
+        ]);
+
+        $response = $this->putJson("/api/words/{$word->id}", [
+            'english_word' => 'apple',
+            'part_of_speech_id' => $pos->id,
+            'translation' => 'new',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertSame('new', $translation->fresh()->translation);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- fix the part-of-speech validation rule in `WordController`
- enable feature testing by adding `CreatesApplication` trait and using it in `TestCase`
- add a new feature test to verify word updates with a valid part of speech

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a386de5cc83298dcc27d0b371ead1